### PR TITLE
Detail corrections for various screens

### DIFF
--- a/src/myapp/components/inputs/recovery-code-input.tsx
+++ b/src/myapp/components/inputs/recovery-code-input.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {StyleSheet, Text, View} from 'react-native';
+import {Platform, StyleSheet, Text, View} from 'react-native';
 // Global styles.
 import globalColors from '../../styles/colors';
 import globalVars from '../../styles/vars';
@@ -36,6 +36,7 @@ const styles = StyleSheet.create({
     fontSize: 20,
     color: globalColors.darkerGray,
     fontFamily: globalVars.fontBold,
+    fontWeight: Platform.OS === 'ios' ? 'bold' : 'normal',
     textAlign: 'center',
   },
 });

--- a/src/myapp/components/inputs/user-input.tsx
+++ b/src/myapp/components/inputs/user-input.tsx
@@ -1,6 +1,7 @@
 import React, {useState, useRef, useEffect} from 'react';
 import {
   Animated,
+  Platform,
   StyleSheet,
   Text,
   TouchableWithoutFeedback,
@@ -118,6 +119,7 @@ const styles = StyleSheet.create({
     color: globalColors.greenSecondary,
     fontSize: 16,
     fontFamily: globalVars.fontBold,
+    fontWeight: Platform.OS === 'ios' ? 'bold' : 'normal',
     marginRight: 10,
   },
   errorOutline: {

--- a/src/myapp/components/inputs/user-textAtea.tsx
+++ b/src/myapp/components/inputs/user-textAtea.tsx
@@ -1,6 +1,7 @@
 import React, {useState, useRef, useEffect} from 'react';
 import {
   Animated,
+  Platform,
   StyleSheet,
   Text,
   TouchableWithoutFeedback,
@@ -119,6 +120,7 @@ const styles = StyleSheet.create({
     color: globalColors.greenSecondary,
     fontSize: 16,
     fontFamily: globalVars.fontBold,
+    fontWeight: Platform.OS === 'ios' ? 'bold' : 'normal',
   },
   errorOutline: {
     borderColor: 'red',

--- a/src/myapp/components/modals/custom-modal.tsx
+++ b/src/myapp/components/modals/custom-modal.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {
   Image,
   Modal,
+  Platform,
   StyleSheet,
   Text,
   TouchableOpacity,
@@ -93,6 +94,7 @@ const styles = StyleSheet.create({
   textCancel: {
     color: globalColors.white,
     fontFamily: globalVars.fontBold,
+    fontWeight: Platform.OS === 'ios' ? 'bold' : 'normal',
     fontSize: 16,
     textAlign: 'center',
     paddingTop: 28,

--- a/src/myapp/components/modals/edit-product-modal.tsx
+++ b/src/myapp/components/modals/edit-product-modal.tsx
@@ -1,5 +1,12 @@
 import React, {useEffect, useState} from 'react';
-import {Modal, StyleSheet, Text, TouchableOpacity, View} from 'react-native';
+import {
+  Modal,
+  Platform,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
 // Global Styles
 import globalColors from '../../styles/colors';
 import globalVars from '../../styles/vars';
@@ -154,6 +161,7 @@ const styles = StyleSheet.create({
   textCancel: {
     color: globalColors.greenSecondary,
     fontFamily: globalVars.fontBold,
+    fontWeight: Platform.OS === 'ios' ? 'bold' : 'normal',
     fontSize: 16,
     textAlign: 'center',
     paddingTop: 28,

--- a/src/myapp/components/navigation/drawer-item.tsx
+++ b/src/myapp/components/navigation/drawer-item.tsx
@@ -6,6 +6,7 @@ import {
   StyleSheet,
   Text,
   TouchableOpacity,
+  Platform,
 } from 'react-native';
 import globalVars from '../../styles/vars';
 import globalColors from '../../styles/colors';
@@ -68,6 +69,7 @@ const styles = StyleSheet.create({
   text: {
     fontSize: 16,
     fontFamily: globalVars.fontBold,
+    fontWeight: Platform.OS === 'ios' ? 'bold' : 'normal',
     paddingLeft: 15,
   },
 });

--- a/src/myapp/components/navigation/drawer-item.tsx
+++ b/src/myapp/components/navigation/drawer-item.tsx
@@ -15,6 +15,7 @@ interface DrawerItemProps {
   title: string;
   currentTab: string;
   setCurrentTab: (title: string) => void;
+  isDisabled?: boolean;
   image: ImageSourcePropType;
   urlKey: string;
   params: {};
@@ -28,11 +29,18 @@ const DrawerItem = (props: DrawerItemProps) => {
 
   return (
     <TouchableOpacity
+      disabled={props.isDisabled}
       onPress={() => {
         props.setCurrentTab(props.title);
         props.onPressOption(props.urlKey, props.params);
       }}>
-      <View style={styles.itemContainer}>
+      <View
+        style={[
+          styles.itemContainer,
+          props.isDisabled && {
+            opacity: 0.4,
+          },
+        ]}>
         <Image
           source={props.image}
           style={[

--- a/src/myapp/components/navigation/home-drawer.tsx
+++ b/src/myapp/components/navigation/home-drawer.tsx
@@ -19,14 +19,13 @@ import globalVars from '../../styles/vars';
 import {useEffect} from 'react';
 
 export const HomeDrawer = (props): DrawerElement => {
-  const authContext = useContext(AuthContext);
   const [currentTab, setCurrentTab] = useState<string>('Mis Mascotas');
   const list = [
     {name: 'Mis Mascotas', ruta: 'Home'},
     {name: 'Info. de Razas', ruta: 'Breed'},
     {name: 'Mi Perfil', ruta: 'MyProfile'},
     {name: 'Adopciones', ruta: 'AdoptionFilter'},
-    {name: 'Productos', ruta: 'AdoptionFilter'},
+    {name: 'Productos', ruta: 'Products'},
   ];
   useEffect(() => {
     list.map((route) => {
@@ -65,6 +64,7 @@ export const HomeDrawer = (props): DrawerElement => {
             image={require('../../assets/images/menu/my-pets.png')}
           />
           <DrawerItem
+            isDisabled
             urlKey="Home"
             params={{}}
             onPressOption={navigateToScreen}
@@ -92,6 +92,7 @@ export const HomeDrawer = (props): DrawerElement => {
             image={require('../../assets/images/menu/products.png')}
           />
           <DrawerItem
+            isDisabled
             urlKey="Home"
             params={{}}
             onPressOption={navigateToScreen}
@@ -101,6 +102,7 @@ export const HomeDrawer = (props): DrawerElement => {
             image={require('../../assets/images/menu/pet-stylists.png')}
           />
           <DrawerItem
+            isDisabled
             urlKey="Home"
             params={{}}
             onPressOption={navigateToScreen}

--- a/src/myapp/components/navigation/home-drawer.tsx
+++ b/src/myapp/components/navigation/home-drawer.tsx
@@ -2,6 +2,7 @@ import React, {useContext, useState} from 'react';
 import {AuthContext} from '../../context/AuthContext';
 import {
   Image,
+  Platform,
   SafeAreaView,
   ScrollView,
   StyleSheet,
@@ -151,6 +152,7 @@ const styles = StyleSheet.create({
   text: {
     fontSize: 16,
     fontFamily: globalVars.fontBold,
+    fontWeight: Platform.OS === 'ios' ? 'bold' : 'normal',
     paddingLeft: 15,
     color: globalColors.greenSecondary,
   },

--- a/src/myapp/components/navigation/home-drawer.tsx
+++ b/src/myapp/components/navigation/home-drawer.tsx
@@ -25,7 +25,7 @@ export const HomeDrawer = (props): DrawerElement => {
     {name: 'Info. de Razas', ruta: 'Breed'},
     {name: 'Mi Perfil', ruta: 'MyProfile'},
     {name: 'Adopciones', ruta: 'AdoptionFilter'},
-    {name: 'Productos', ruta: 'Products'},
+    {name: 'Productos', ruta: 'ProductList'},
   ];
   useEffect(() => {
     list.map((route) => {

--- a/src/myapp/hooks/adoption/useAdoption.ts
+++ b/src/myapp/hooks/adoption/useAdoption.ts
@@ -12,7 +12,6 @@ const useAdoption = () => {
       // Save Pet image.
       queryClient.invalidateQueries('request-adoptionAll');
       queryClient.invalidateQueries('adoption-request');
-      navigation.goBack();
     },
   });
 };

--- a/src/myapp/hooks/adoption/useAdoption.ts
+++ b/src/myapp/hooks/adoption/useAdoption.ts
@@ -1,15 +1,13 @@
 import api from '../../services/app-services';
-import {useNavigation} from '@react-navigation/native';
 import {useMutation, useQueryClient} from 'react-query';
 
 const AddAdoption = (data) => api.post('api/v1/adoption-request/', data, true);
 
 const useAdoption = () => {
-  const navigation = useNavigation();
   const queryClient = useQueryClient();
   return useMutation((data: any) => AddAdoption(data), {
     onSuccess: () => {
-      // Save Pet image.
+      // Save adoption.
       queryClient.invalidateQueries('request-adoptionAll');
       queryClient.invalidateQueries('adoption-request');
     },

--- a/src/myapp/hooks/orders/useSalesOrders.ts
+++ b/src/myapp/hooks/orders/useSalesOrders.ts
@@ -1,8 +1,7 @@
 import {useQuery} from 'react-query';
 import api from '../../services/app-services';
 
-const useSalesOrders = () => {
-  return useQuery('get-orders', () => api.get('api/v1/sales-order/', true));
-};
+const useSalesOrders = () =>
+  useQuery('get-orders', () => api.get('api/v1/sales-order/', true));
 
 export default useSalesOrders;

--- a/src/myapp/layouts/addresses/index.tsx
+++ b/src/myapp/layouts/addresses/index.tsx
@@ -1,5 +1,5 @@
 import React, {useState, useEffect} from 'react';
-import {Image, StyleSheet} from 'react-native';
+import {Image, Platform, StyleSheet} from 'react-native';
 import {List} from '@ui-kitten/components';
 // My components
 import DefaultLayout from '../../components/layouts/default-layout';
@@ -129,6 +129,7 @@ const styles = StyleSheet.create({
   },
   subtitle: {
     fontFamily: globalVars.fontBold,
+    fontWeight: Platform.OS === 'ios' ? 'bold' : 'normal',
   },
   servicesContainer: {
     backgroundColor: 'transparent',

--- a/src/myapp/layouts/adoption/detail/index.tsx
+++ b/src/myapp/layouts/adoption/detail/index.tsx
@@ -1,5 +1,5 @@
 import React, {useEffect, useState} from 'react';
-import {ScrollView, StyleSheet, Text, View} from 'react-native';
+import {Platform, ScrollView, StyleSheet, Text, View} from 'react-native';
 // Env
 import environments from '../../../environments';
 // Global Styles.
@@ -154,6 +154,7 @@ const styles = StyleSheet.create({
   },
   subTitle: {
     fontFamily: globalVars.fontBold,
+    fontWeight: Platform.OS === 'ios' ? 'bold' : 'normal',
     fontSize: 16,
     color: globalColors.darkerGray,
     alignItems: 'center',

--- a/src/myapp/layouts/adoption/filter/index.tsx
+++ b/src/myapp/layouts/adoption/filter/index.tsx
@@ -117,11 +117,7 @@ export default ({navigation}): React.ReactElement => {
           idTown={form.town}
         />
         <CustomButton
-          style={
-            statusBtn
-              ? {backgroundColor: globalColors.lightGray, marginTop: 14}
-              : {marginTop: 14}
-          }
+          style={[styles.button, statusBtn && styles.disabledButton]}
           isDisabled={statusBtn}
           isLoading={isLoding}
           onPress={() => {
@@ -145,7 +141,8 @@ const themedStyles = StyleService.create({
   },
   imagePort: {
     width: width,
-    height: 320,
+    maxHeight: 320,
+    height: '42%',
   },
   layoutPort: {
     marginLeft: 24,
@@ -162,5 +159,11 @@ const themedStyles = StyleService.create({
     fontFamily: globalVars.fontRegular,
     fontSize: 18,
     color: globalColors.darkGray,
+  },
+  button: {
+    marginVertical: 14,
+  },
+  disabledButton: {
+    backgroundColor: globalColors.lightGray,
   },
 });

--- a/src/myapp/layouts/adoption/filter/index.tsx
+++ b/src/myapp/layouts/adoption/filter/index.tsx
@@ -1,7 +1,7 @@
 import React, {useEffect, useState} from 'react';
 import {Layout, StyleService, useStyleSheet} from '@ui-kitten/components';
 import DefaultLayout from '../../../components/layouts/default-layout';
-import {Dimensions, Image} from 'react-native';
+import {Dimensions, Image, Platform} from 'react-native';
 // Global styles
 import globalColors from '../../../styles/colors';
 import globalVars from '../../../styles/vars';
@@ -152,6 +152,7 @@ const themedStyles = StyleService.create({
   },
   textTitle: {
     fontFamily: globalVars.fontBold,
+    fontWeight: Platform.OS === 'ios' ? 'bold' : 'normal',
     fontSize: 22,
   },
   textContent: {

--- a/src/myapp/layouts/adoption/my-requests/index.tsx
+++ b/src/myapp/layouts/adoption/my-requests/index.tsx
@@ -1,5 +1,5 @@
 import React, {useState} from 'react';
-import {Image, StyleSheet} from 'react-native';
+import {Dimensions, Image, Platform, StyleSheet} from 'react-native';
 import {List} from '@ui-kitten/components';
 // Environment
 import environments from '../../../environments';
@@ -119,6 +119,7 @@ export default ({navigation, route}): React.ReactElement => {
   );
 };
 
+const {width} = Dimensions.get('window');
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -127,6 +128,7 @@ const styles = StyleSheet.create({
   dogImage: {
     alignSelf: 'center',
     resizeMode: 'contain',
+    width: width,
     height: 390,
     maxHeight: 390,
     marginVertical: 5,
@@ -137,6 +139,7 @@ const styles = StyleSheet.create({
   },
   subtitle: {
     fontFamily: globalVars.fontBold,
+    fontWeight: Platform.OS === 'ios' ? 'bold' : 'normal',
   },
   servicesContainer: {
     backgroundColor: 'transparent',

--- a/src/myapp/layouts/adoption/request/index.tsx
+++ b/src/myapp/layouts/adoption/request/index.tsx
@@ -1,19 +1,32 @@
-import React, {useEffect} from 'react';
-import DefaultLayout from '../../../components/layouts/default-layout';
-import TitleHeader from '../../../components/texts/title-header';
-import DefaultText from '../../../components/texts/default-text';
-import UserInput from '../../../components/inputs/user-input';
-import {useState} from 'react';
-import CustomButton from '../../../components/buttons/custom-button';
-import {View, ScrollView} from 'react-native';
-import OptionSelect from '../../../components/inputs/option-select';
-import CustomModal from '../../../components/modals/custom-modal';
-import UserTextArea from '../../../components/inputs/user-textAtea';
+import React, {useEffect, useState} from 'react';
+import {View, ScrollView, StyleSheet} from 'react-native';
+// Hooks
 import useAdoption from '../../../hooks/adoption/useAdoption';
 import useStates from '../../../hooks/util/useState';
+// My Components
+import CloseButton from '../../../components/buttons/close-button';
+import CustomButton from '../../../components/buttons/custom-button';
+import CustomModal from '../../../components/modals/custom-modal';
+import DefaultLayout from '../../../components/layouts/default-layout';
+import DefaultText from '../../../components/texts/default-text';
 import DropdownPicker from '../../../components/inputs/dropdown-picker';
 import MunicipalityDrop from '../../../components/adoption/municipality-drop';
-import CloseButton from '../../../components/buttons/close-button';
+import OptionSelect from '../../../components/inputs/option-select';
+import TitleHeader from '../../../components/texts/title-header';
+import UserInput from '../../../components/inputs/user-input';
+import UserTextArea from '../../../components/inputs/user-textAtea';
+// Types
+import {BaseModel, ErrorResponse} from '../../../types/models';
+import globalVars from '../../../styles/vars';
+import globalColors from '../../../styles/colors';
+
+const initialErrors = {
+  cp: '',
+  cel: '',
+  reason: '',
+  tel: '',
+  generic: '',
+};
 
 export default ({navigation, route}): React.ReactElement => {
   const [form, setForm] = useState({
@@ -37,25 +50,29 @@ export default ({navigation, route}): React.ReactElement => {
     qresource: '',
   });
   const [isModalVisible, setIsModalVisible] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
   const [stateList, setStateList] = useState([]);
+  const [errors, setErrors] = useState(initialErrors);
   const useAddQuery = useAdoption();
   const dataStates = useStates();
+  const isValid =
+    form.cel.length === 10 &&
+    form.tel.length === 10 &&
+    form.cp.length === 5 &&
+    form.reason.length >= 20;
+
   const isDisable =
     form.age !== '' &&
     form.sex !== '' &&
     form.occupation !== '' &&
     form.street !== '' &&
     form.number !== '' &&
-    form.cp.length === 5 &&
-    form.cel.length === 10 &&
-    form.tel.length === 10 &&
     form.cologne !== '' &&
     form.city !== '' &&
     form.municipality !== '' &&
     form.state !== '' &&
     form.qpet !== '' &&
     form.qact !== '' &&
-    form.reason.length >= 20 &&
     form.qcount !== '' &&
     form.qallirgic !== '' &&
     form.qresource !== '';
@@ -63,7 +80,7 @@ export default ({navigation, route}): React.ReactElement => {
   useEffect(() => {
     if (dataStates.data) {
       const aux = [];
-      dataStates.data.data.forEach((element) => {
+      dataStates.data.data.forEach((element: BaseModel) => {
         aux.push({
           value: element.id,
           label: element.name,
@@ -81,6 +98,7 @@ export default ({navigation, route}): React.ReactElement => {
     {key: 'S', value: 'Si'},
     {key: 'N', value: 'No'},
   ];
+
   const onAdoption = () => {
     const request = {
       adoption_publication: route.params.adoption.id,
@@ -129,25 +147,57 @@ export default ({navigation, route}): React.ReactElement => {
       },
       data: route.params.adoption,
     };
-    useAddQuery.mutate(request);
+    useAddQuery.mutate(request, {
+      onSuccess: () => {
+        setIsModalVisible(true);
+      },
+      onError: (error: ErrorResponse) => {
+        setErrors({
+          ...errors,
+          generic:
+            'Hubo un problema al enviar la solicitud. Intenta nuevamente más tarde.',
+        });
+      },
+    });
   };
+
+  const setFormDataErrorMessages = () => {
+    setErrors({
+      ...errors,
+      cel: form.cel.length === 10 ? '' : 'El celular debe tener 10 dígitos',
+      tel:
+        form.tel.length === 10 ? '' : 'El teléfono fijo debe tener 10 dígitos',
+      cp: form.cp.length === 5 ? '' : 'El código postal debe tener 5 dígitos',
+      reason:
+        form.reason.length >= 20
+          ? ''
+          : 'El motivo debe contener al menos 25 caracteres',
+    });
+  };
+
   navigation.setOptions({
     headerLeft: () => <CloseButton navigation={navigation} />,
   });
+
+  const errorMessage = Object.entries(errors)
+    .map((error) => error[1])
+    .filter((error) => error !== '')
+    .join('\n');
+
   return (
-    <DefaultLayout>
+    <DefaultLayout style={styles.container}>
       <CustomModal
         labelAccept="Entendido"
         title="Solicitud Enviada"
         text="La solicitud la analizará la asociación y se pondrá en
         contacto contigo en caso de ser aprobada para continuar con el proceso y de ser necesario
         solicitarte más información."
-        onAccept={onAdoption}
+        onAccept={() => navigation.goBack()}
         onCancel={() => {}}
         showCancel={false}
         visible={isModalVisible}
       />
-      <ScrollView>
+      <ScrollView style={styles.scrollView}>
         <TitleHeader>Solicitud de adopción</TitleHeader>
         <DefaultText style={{marginBottom: 48}}>
           Por favor llena los siguientes datos para ponernos en contacto
@@ -196,6 +246,7 @@ export default ({navigation, route}): React.ReactElement => {
           }}
         />
         <UserInput
+          error={errors.cp}
           placeholder="CP"
           isNumeric={true}
           maxLength={5}
@@ -229,6 +280,7 @@ export default ({navigation, route}): React.ReactElement => {
           }}
         />
         <UserInput
+          error={errors.cel}
           placeholder="Celular"
           value={form.cel}
           isNumeric={true}
@@ -238,6 +290,7 @@ export default ({navigation, route}): React.ReactElement => {
           }}
         />
         <UserInput
+          error={errors.tel}
           placeholder="Teléfono fijo"
           value={form.tel}
           isNumeric={true}
@@ -271,6 +324,7 @@ export default ({navigation, route}): React.ReactElement => {
         <TitleHeader>¿Qué te motivó a adoptar?</TitleHeader>
         <View style={{marginBottom: 15}}>
           <UserTextArea
+            error={errors.reason}
             placeholder="Motivos"
             value={form.reason}
             onChangeText={(value: string) => {
@@ -322,18 +376,20 @@ export default ({navigation, route}): React.ReactElement => {
           *La dirección registrada en la solicitud, podrá utilizada por las
           asociaciones para una visita presencial
         </DefaultText>
+        <DefaultText style={styles.errorMessage}>{errorMessage}</DefaultText>
         <CustomButton
-          style={
-            !isDisable
-              ? {
-                  marginTop: 50,
-                  marginBottom: 20,
-                }
-              : {marginTop: 50, marginBottom: 20}
-          }
+          style={styles.submitButton}
           isDisabled={!isDisable}
+          isLoading={isLoading}
           onPress={() => {
-            setIsModalVisible(true);
+            setIsLoading(true);
+            if (isValid) {
+              setErrors(initialErrors);
+              onAdoption();
+            } else {
+              setFormDataErrorMessages();
+            }
+            setIsLoading(false);
           }}>
           Solicitar Adopción
         </CustomButton>
@@ -341,3 +397,20 @@ export default ({navigation, route}): React.ReactElement => {
     </DefaultLayout>
   );
 };
+
+const styles = StyleSheet.create({
+  container: {
+    paddingRight: globalVars.outsidePadding / 2,
+  },
+  scrollView: {
+    paddingRight: globalVars.outsidePadding / 2,
+  },
+  errorMessage: {
+    color: globalColors.red,
+    marginTop: 16,
+  },
+  submitButton: {
+    marginBottom: globalVars.outsidePadding,
+    marginTop: 50,
+  },
+});

--- a/src/myapp/layouts/adoption/result/index.tsx
+++ b/src/myapp/layouts/adoption/result/index.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import {Layout, StyleService, useStyleSheet, List} from '@ui-kitten/components';
-import {Dimensions, Image, View} from 'react-native';
+import {Dimensions, Image, Platform, View} from 'react-native';
 import {Text} from '@ui-kitten/components';
 import {TouchableOpacity} from 'react-native-gesture-handler';
 // Env
 import environments from '../../../environments';
 // Global Styles
 import globalColors from '../../../styles/colors';
+import globalVars from '../../../styles/vars';
 // My Components
 import AnchorText from '../../../components/texts/anchor-text';
 import DefaultLayout from '../../../components/layouts/default-layout';
@@ -146,8 +147,10 @@ export default ({navigation, route}): React.ReactElement => {
             source={require('../assets/adoptionNo.png')}
           />
           <Layout style={styles.layoutPort}>
-            <TitleHeader>No se encontraron resultados</TitleHeader>
-            <DefaultText style={{alignItems: 'center'}}>
+            <TitleHeader style={styles.title}>
+              No se encontraron resultados
+            </TitleHeader>
+            <DefaultText style={styles.subtitle}>
               Intenta cambiar las opciones de filtros para obtener mejores
               resultados.
             </DefaultText>
@@ -199,5 +202,13 @@ const themedStyles = StyleService.create({
     height: '52%',
     borderTopLeftRadius: 18,
     borderTopRightRadius: 18,
+  },
+  title: {
+    textAlign: 'center',
+  },
+  subtitle: {
+    textAlign: 'center',
+    fontFamily: globalVars.fontBold,
+    fontWeight: Platform.OS === 'ios' ? 'bold' : 'normal',
   },
 });

--- a/src/myapp/layouts/breed/detail/index.tsx
+++ b/src/myapp/layouts/breed/detail/index.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {
   Dimensions,
   ImageBackground,
+  Platform,
   ScrollView,
   StyleSheet,
   Text,
@@ -150,6 +151,7 @@ const styles = StyleSheet.create({
   subtitulo: {
     fontSize: 16,
     fontFamily: globalVars.fontBold,
+    fontWeight: Platform.OS === 'ios' ? 'bold' : 'normal',
     marginTop: 32,
   },
   label: {

--- a/src/myapp/layouts/breed/detail/index.tsx
+++ b/src/myapp/layouts/breed/detail/index.tsx
@@ -40,13 +40,13 @@ export default ({route}): React.ReactElement => {
         <Text style={styles.subtitulo}>Principales características</Text>
         <Text style={styles.label}>{item.main_characteristics}</Text>
         <Text style={styles.subtitulo}>Nivel energético</Text>
-        <PawBreed numberTteam={5} number={parseInt(item.energy_level, 2)} />
+        <PawBreed numberTteam={5} number={parseInt(item.energy_level, 10)} />
         <Text style={styles.subtitulo}>Tendencia a babear</Text>
-        <PawBreed numberTteam={5} number={parseInt(item.slobber_level, 2)} />
+        <PawBreed numberTteam={5} number={parseInt(item.slobber_level, 10)} />
         <Text style={styles.subtitulo}>Tendencia a ladrar</Text>
-        <PawBreed numberTteam={5} number={parseInt(item.barking_level, 2)} />
+        <PawBreed numberTteam={5} number={parseInt(item.barking_level, 10)} />
         <Text style={styles.subtitulo}>Necesidad de atención</Text>
-        <PawBreed numberTteam={5} number={parseInt(item.attention_level, 2)} />
+        <PawBreed numberTteam={5} number={parseInt(item.attention_level, 10)} />
       </View>
     );
   };

--- a/src/myapp/layouts/breed/detail/index.tsx
+++ b/src/myapp/layouts/breed/detail/index.tsx
@@ -20,52 +20,33 @@ import TitleHeader from '../../../components/texts/title-header';
 export default ({route}): React.ReactElement => {
   const data = [route.params.breed];
   const image = require('../assets/dog-notFound.jpg');
-  const renderDataItem = (service) => {
+  const renderDataItem = ({item}) => {
     return (
       <View style={styles.servicesContainer}>
         <Text style={styles.subtitulo}>Descripción general</Text>
-        <Text style={styles.label}>{service.item.description}</Text>
+        <Text style={styles.label}>{item.description}</Text>
         <Text style={styles.subtitulo}>Tamaño</Text>
-        <Text style={styles.label}>{service.item.size.name}</Text>
+        <Text style={styles.label}>{item.size.name}</Text>
         <Text style={styles.subtitulo}>Peso</Text>
         <Text style={styles.label}>
-          Entre de {service.item.min_weight} y {service.item.max_weight} kg
+          Entre de {item.min_weight} y {item.max_weight} kg
         </Text>
         <Text style={styles.subtitulo}>Altura</Text>
         <Text style={styles.label}>
-          Entre de {service.item.min_height} y {service.item.max_height} cm
+          Entre de {item.min_height} y {item.max_height} cm
         </Text>
         <Text style={styles.subtitulo}>Esperanza de vida</Text>
-        <Text style={styles.label}>{service.item.life_expectancy} años</Text>
-        <Text style={styles.subtitulo}>Criado para</Text>
-        <Text style={styles.label}>{service.item.purpose}</Text>
+        <Text style={styles.label}>{item.life_expectancy} años</Text>
         <Text style={styles.subtitulo}>Principales características</Text>
-        <Text style={styles.label}>{service.item.main_characteristics}</Text>
+        <Text style={styles.label}>{item.main_characteristics}</Text>
         <Text style={styles.subtitulo}>Nivel energético</Text>
-        <PawBreed
-          numberTteam={5}
-          number={parseInt(service.item.energy_level, 2)}
-        />
+        <PawBreed numberTteam={5} number={parseInt(item.energy_level, 2)} />
         <Text style={styles.subtitulo}>Tendencia a babear</Text>
-        <PawBreed
-          numberTteam={5}
-          number={parseInt(service.item.slobber_level, 2)}
-        />
-        <Text style={styles.subtitulo}>Tendencia a roncar</Text>
-        <PawBreed
-          numberTteam={5}
-          number={parseInt(service.item.snoring_level, 2)}
-        />
+        <PawBreed numberTteam={5} number={parseInt(item.slobber_level, 2)} />
         <Text style={styles.subtitulo}>Tendencia a ladrar</Text>
-        <PawBreed
-          numberTteam={5}
-          number={parseInt(service.item.barking_level, 2)}
-        />
+        <PawBreed numberTteam={5} number={parseInt(item.barking_level, 2)} />
         <Text style={styles.subtitulo}>Necesidad de atención</Text>
-        <PawBreed
-          numberTteam={5}
-          number={parseInt(service.item.attention_level, 2)}
-        />
+        <PawBreed numberTteam={5} number={parseInt(item.attention_level, 2)} />
       </View>
     );
   };

--- a/src/myapp/layouts/breed/inf/index.tsx
+++ b/src/myapp/layouts/breed/inf/index.tsx
@@ -10,7 +10,7 @@ import {
   useStyleSheet,
 } from '@ui-kitten/components';
 import React, {useEffect} from 'react';
-import {Dimensions, Image, View} from 'react-native';
+import {Dimensions, Image, Platform, View} from 'react-native';
 // Global Styles
 import globalColors from '../../../styles/colors';
 import globalVars from '../../../styles/vars';
@@ -130,6 +130,7 @@ const themedStyles = StyleService.create({
     marginTop: 20,
     marginLeft: 24,
     fontFamily: globalVars.fontBold,
+    fontWeight: Platform.OS === 'ios' ? 'bold' : 'normal',
     fontSize: 20,
   },
   filter: {
@@ -159,6 +160,7 @@ const themedStyles = StyleService.create({
   },
   tituloCard: {
     fontFamily: globalVars.fontBold,
+    fontWeight: Platform.OS === 'ios' ? 'bold' : 'normal',
     fontSize: 20,
     marginTop: 14,
     marginLeft: 15,
@@ -169,6 +171,7 @@ const themedStyles = StyleService.create({
   },
   labelNot: {
     fontFamily: globalVars.fontBold,
+    fontWeight: Platform.OS === 'ios' ? 'bold' : 'normal',
     fontSize: 20,
     alignSelf: 'center',
     marginTop: 20,

--- a/src/myapp/layouts/deworming/history/index.tsx
+++ b/src/myapp/layouts/deworming/history/index.tsx
@@ -1,5 +1,5 @@
 import React, {useEffect, useLayoutEffect, useState} from 'react';
-import {Image, Dimensions} from 'react-native';
+import {Image, Dimensions, Platform} from 'react-native';
 // Global Styles
 import globalColors from '../../../styles/colors';
 import globalVars from '../../../styles/vars';
@@ -144,11 +144,23 @@ export default ({navigation, route}): React.ReactElement => {
         <TitleHeader children="Desparasitaciones" style={styles.center} />
         <DefaultText
           children="Aún no has agregado desparasitaciones"
-          style={[styles.center, {fontFamily: globalVars.fontBold}]}
+          style={[
+            styles.center,
+            {
+              fontFamily: globalVars.fontBold,
+              fontWeight: Platform.OS === 'ios' ? 'bold' : 'normal',
+            },
+          ]}
         />
         <DefaultText
           children="para tu mascota."
-          style={[styles.center, {fontFamily: globalVars.fontBold}]}
+          style={[
+            styles.center,
+            {
+              fontFamily: globalVars.fontBold,
+              fontWeight: Platform.OS === 'ios' ? 'bold' : 'normal',
+            },
+          ]}
         />
       </Layout>
     </DefaultLayout>

--- a/src/myapp/layouts/home/index.tsx
+++ b/src/myapp/layouts/home/index.tsx
@@ -21,19 +21,22 @@ import {TouchableOpacity} from 'react-native-gesture-handler';
 
 const servicesList = [
   {
-    serviceName: 'Veterinaria',
+    disabled: true,
     icon: require('../../assets/images/menu/vets.png'),
     route: 'Home',
+    serviceName: 'Veterinaria',
   },
   {
-    serviceName: 'Estética',
+    disabled: true,
     icon: require('../../assets/images/menu/pet-stylists.png'),
     route: 'Home',
+    serviceName: 'Estética',
   },
   {
-    serviceName: 'Productos',
+    disabled: false,
     icon: require('../../assets/images/menu/products.png'),
     route: 'ProductList',
+    serviceName: 'Productos',
   },
 ];
 
@@ -70,7 +73,13 @@ export default ({navigation}): React.ReactElement => {
 
   const renderServiceItem = (service) => (
     <TouchableOpacity
-      style={styles.serviceContainer}
+      disabled={service.disabled}
+      style={[
+        styles.serviceContainer,
+        service.disabled && {
+          opacity: 0.3,
+        },
+      ]}
       onPress={() => navigation.navigate(service.route, {})}>
       <Card activeOpacity={0.8} style={styles.serviceIconContainer}>
         <Image style={styles.serviceIcon} source={service.icon} />

--- a/src/myapp/layouts/orders/detail/index.tsx
+++ b/src/myapp/layouts/orders/detail/index.tsx
@@ -8,6 +8,7 @@ import DefaultText from '../../../components/texts/default-text';
 import GenericCard from '../../../components/cards/generic-card';
 // Global Styles
 import globalColors from '../../../styles/colors';
+import globalVars from '../../../styles/vars';
 
 export default ({navigation, route}): React.ReactElement => {
   const orderSale = route.params.order;
@@ -39,10 +40,7 @@ export default ({navigation, route}): React.ReactElement => {
     }`,
     images: null,
     styleCard: {},
-    title:
-      orderSale.tracking_number === null
-        ? 'Estamos trabajando en tu pedido'
-        : `#${orderSale.tracking_number}`,
+    title: `#${orderSale.id}`,
   };
 
   const dataDelivery = {
@@ -109,9 +107,9 @@ export default ({navigation, route}): React.ReactElement => {
   };
 
   return (
-    <DefaultLayout>
+    <DefaultLayout style={styles.container}>
       <TitleHeader style={{marginBottom: 24}}>Detalle de Pedido</TitleHeader>
-      <ScrollView>
+      <ScrollView style={styles.scrollView}>
         <GenericCard
           data={data}
           styleCard={{marginHorizontal: 0}}
@@ -165,6 +163,12 @@ export default ({navigation, route}): React.ReactElement => {
 };
 
 const styles = StyleSheet.create({
+  container: {
+    paddingRight: globalVars.outsidePadding / 2,
+  },
+  scrollView: {
+    paddingRight: globalVars.outsidePadding / 2,
+  },
   servicesContainer: {
     backgroundColor: 'transparent',
     marginBottom: 10,

--- a/src/myapp/layouts/orders/index.tsx
+++ b/src/myapp/layouts/orders/index.tsx
@@ -1,5 +1,5 @@
 import React, {useState, useEffect} from 'react';
-import {Image, StyleSheet} from 'react-native';
+import {Image, Platform, StyleSheet} from 'react-native';
 import {List} from '@ui-kitten/components';
 // My components
 import DefaultLayout from '../../components/layouts/default-layout';
@@ -98,6 +98,7 @@ const styles = StyleSheet.create({
   },
   subtitle: {
     fontFamily: globalVars.fontBold,
+    fontWeight: Platform.OS === 'ios' ? 'bold' : 'normal',
   },
   servicesContainer: {
     backgroundColor: 'transparent',

--- a/src/myapp/layouts/orders/index.tsx
+++ b/src/myapp/layouts/orders/index.tsx
@@ -1,17 +1,17 @@
 import React, {useState, useEffect} from 'react';
 import {Image, Platform, StyleSheet} from 'react-native';
 import {List} from '@ui-kitten/components';
+// Hooks
+import useSalesOrders from '../../hooks/orders/useSalesOrders';
 // My components
+import CustomSpinner from '../../components/custom-spinner';
 import DefaultLayout from '../../components/layouts/default-layout';
-import TitleHeader from '../../components/texts/title-header';
 import DefaultText from '../../components/texts/default-text';
 import GenericCard from '../../components/cards/generic-card';
-
-import CustomSpinner from '../../components/custom-spinner';
+import TitleHeader from '../../components/texts/title-header';
 // Global Styles
-import globalVars from '../../styles/vars';
 import globalColors from '../../styles/colors';
-import useSalesOrders from '../../hooks/orders/useSalesOrders';
+import globalVars from '../../styles/vars';
 
 export default ({navigation}): React.ReactElement => {
   const [salesOrders, setSalesOrders] = useState([]);
@@ -24,10 +24,7 @@ export default ({navigation}): React.ReactElement => {
   }, [myOrders.data]);
 
   const renderItem = (order) => {
-    const trackingNumber =
-      order.item.tracking_number === null
-        ? 'Estamos trabajando en tu pedido'
-        : `#${order.item.tracking_number}`;
+    const trackingNumber = `#${order.item.id}`;
     const status = order.item.status;
     const deliveryTime =
       order.item.delivery_time === null
@@ -58,7 +55,7 @@ export default ({navigation}): React.ReactElement => {
   return myOrders.isLoading ? (
     <CustomSpinner />
   ) : salesOrders.length > 0 ? (
-    <DefaultLayout>
+    <DefaultLayout style={styles.container}>
       <TitleHeader style={{marginBottom: 20}}>Pedidos</TitleHeader>
       <List
         style={styles.servicesContainer}
@@ -83,7 +80,7 @@ export default ({navigation}): React.ReactElement => {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    paddingHorizontal: 0,
+    paddingRight: globalVars.outsidePadding / 2,
   },
   dogImage: {
     alignSelf: 'center',
@@ -103,5 +100,6 @@ const styles = StyleSheet.create({
   servicesContainer: {
     backgroundColor: 'transparent',
     marginBottom: 10,
+    paddingRight: globalVars.outsidePadding / 2,
   },
 });

--- a/src/myapp/layouts/payment-method/index.tsx
+++ b/src/myapp/layouts/payment-method/index.tsx
@@ -1,5 +1,5 @@
 import React, {useState, useEffect} from 'react';
-import {Image, StyleSheet} from 'react-native';
+import {Image, Platform, StyleSheet} from 'react-native';
 import {List} from '@ui-kitten/components';
 // My components
 import DefaultLayout from '../../components/layouts/default-layout';
@@ -122,6 +122,7 @@ const styles = StyleSheet.create({
   },
   subtitle: {
     fontFamily: globalVars.fontBold,
+    fontWeight: Platform.OS === 'ios' ? 'bold' : 'normal',
   },
   servicesContainer: {
     backgroundColor: 'transparent',

--- a/src/myapp/layouts/products/detail/index.tsx
+++ b/src/myapp/layouts/products/detail/index.tsx
@@ -116,11 +116,16 @@ export default ({route}): React.ReactElement => {
             style={styles.containerCarousel}
           />
         ) : (
-          <Image
-            style={styles.imageProduct}
-            source={{
-              uri: route.params.cover_image,
-            }}
+          <ImageCarousel
+            gradientBottomStyles={styles.gradientBottom}
+            gradientTopStyles={styles.gradientTop}
+            images={[
+              {
+                uri: route.params.cover_image,
+              },
+            ]}
+            imagesStyle={styles.images}
+            style={styles.containerCarousel}
           />
         )}
       </View>

--- a/src/myapp/layouts/start/index.tsx
+++ b/src/myapp/layouts/start/index.tsx
@@ -1,5 +1,5 @@
 import React, {useContext} from 'react';
-import {Dimensions, Image, StyleSheet, View} from 'react-native';
+import {Dimensions, Image, Platform, StyleSheet, View} from 'react-native';
 import {Text} from '@ui-kitten/components';
 // Context
 import {AuthContext, AuthContextType} from '../../context/AuthContext';
@@ -95,6 +95,7 @@ const styles = StyleSheet.create({
     lineHeight: 34,
     marginBottom: 24,
     fontFamily: globalVars.fontBold,
+    fontWeight: Platform.OS === 'ios' ? 'bold' : 'normal',
   },
   signUpButton: {
     marginBottom: 24,

--- a/src/myapp/layouts/vaccines/vaccine-index/index.tsx
+++ b/src/myapp/layouts/vaccines/vaccine-index/index.tsx
@@ -1,5 +1,5 @@
 import React, {useLayoutEffect, useEffect, useState} from 'react';
-import {Image, StyleSheet} from 'react-native';
+import {Image, Platform, StyleSheet} from 'react-native';
 // My Components.
 import AddButton from '../../../components/buttons/add-button';
 import DefaultLayout from '../../../components/layouts/default-layout';
@@ -171,6 +171,7 @@ const styles = StyleSheet.create({
   },
   subtitle: {
     fontFamily: globalVars.fontBold,
+    fontWeight: Platform.OS === 'ios' ? 'bold' : 'normal',
   },
   servicesContainer: {
     backgroundColor: 'transparent',

--- a/src/myapp/layouts/visits/inf/index.tsx
+++ b/src/myapp/layouts/visits/inf/index.tsx
@@ -1,6 +1,6 @@
 import {useEffect} from 'react';
 import React, {useLayoutEffect} from 'react';
-import {Image, Dimensions, View, StyleSheet} from 'react-native';
+import {Image, Dimensions, View, StyleSheet, Platform} from 'react-native';
 import {List} from '@ui-kitten/components';
 // Global Styles.
 import globalColors from '../../../styles/colors';
@@ -117,6 +117,7 @@ const styles = StyleSheet.create({
   },
   textLabel: {
     fontFamily: globalVars.fontBold,
+    fontWeight: Platform.OS === 'ios' ? 'bold' : 'normal',
     textAlign: 'center',
   },
   dogImage: {


### PR DESCRIPTION
Features:
-
- Show linear gradients on products detail image when using the cover_image
- Style corrections for adoptions screens
- Added font weight bold property required for iOS that was missing on multiple screens
- Removed snoring level and breeding purpose on the breeds information screens
- Fixed bug on the breed levels that was causing the levels to render with only 0 or 1 paws
- Disabled not available options from the menu and the home-screen
- Changed the title of the sales orders cards and detail screens to be the id of the order instead of the tracking number
