### PR TITLE
Changed max character limit on text area

### DIFF
--- a/src/myapp/components/inputs/user-textAtea.tsx
+++ b/src/myapp/components/inputs/user-textAtea.tsx
@@ -83,7 +83,7 @@ const UserTextArea = (props: UserInputProps): React.ReactElement => {
         textStyle={[styles.inputValueText, {paddingTop: inputPadding}]}
         value={props.value}
         multiline={true}
-        maxLength={160}
+        maxLength={100}
       />
     </View>
   );


### PR DESCRIPTION
Since the max limit for the text area input was 160, the adoption request endpoint was returning an error about the 100 character limit that was accepted on the "Reason to adopt" field when sending the 160 characters.