### PR TITLE
Android conflicting camera permission

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -2,7 +2,6 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
-    <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.DOWNLOAD_WITHOUT_NOTIFICATION" />
 


### PR DESCRIPTION
The camera permission on the manifest was conflicting with the library we use to open the camera. By removing it the problem is solved and we can use both the camera or the gallery.

Reference:
https://github.com/react-native-image-picker/react-native-image-picker#android
