### PR TITLE
Mime Type on filename correction and image size correction for gallery images

### DIFF
--- a/src/myapp/components/inputs/pet-image-input.tsx
+++ b/src/myapp/components/inputs/pet-image-input.tsx
@@ -59,15 +59,18 @@ const PetImageInput = ({
           onPress: () => {
             if (Platform.OS === 'ios') {
               openPicker({
-                width: 500,
-                height: 500,
                 cropping: false,
                 compressImageQuality: 0.5,
+                mediaType: 'photo',
+                forceJpg: true,
+                multiple: false,
+                compressImageMaxHeight: 501,
+                compressImageMaxWidth: 500,
               }).then((newImage) => {
                 const imageData = {
-                  fileName: newImage.filename,
+                  fileName: newImage.filename.split('.HEIC')[0] + '.jpg',
                   type: newImage.mime,
-                  uri: newImage.sourceURL,
+                  uri: newImage.path,
                 };
                 setImage(imageData);
               });

--- a/src/myapp/hooks/images/useLaunchCamera.ts
+++ b/src/myapp/hooks/images/useLaunchCamera.ts
@@ -51,13 +51,14 @@ const useLaunchCamera = (setImage: (image: ImageSourcePropType) => void) => {
                 compressImageQuality: 0.5,
                 mediaType: 'photo',
                 forceJpg: true,
-                compressImageMaxHeight: 500,
+                multiple: false,
+                compressImageMaxHeight: 501,
                 compressImageMaxWidth: 500,
               }).then((newImage) => {
                 const imageData = {
-                  fileName: newImage.filename,
+                  fileName: newImage.filename.split('.HEIC')[0] + '.jpg',
                   type: newImage.mime,
-                  uri: newImage.sourceURL,
+                  uri: newImage.path,
                 };
                 setImage(imageData);
               });


### PR DESCRIPTION
Corrected mime type set in the filename for images on iOS, so it is only jpg images. The mime type of the file was being set correctly as jpg, but the filename was still saying .HEIC. Also changed the uri source from the "sourceURL" var to the "path" var, since that is the one the library returns as jpg

Also added a workaround for images not being set to the max size, which was to set max width and height a pixel apart from each other. The issue was with the library for the specific case when both max sizes were set to the same size.