### PR TITLE
(iOS) Added timestamp to file name

### DIFF
--- a/src/myapp/components/inputs/pet-image-input.tsx
+++ b/src/myapp/components/inputs/pet-image-input.tsx
@@ -68,7 +68,11 @@ const PetImageInput = ({
                 compressImageMaxWidth: 500,
               }).then((newImage) => {
                 const imageData = {
-                  fileName: newImage.filename.split('.HEIC')[0] + '.jpg',
+                  fileName:
+                    Date.now() +
+                    '-' +
+                    newImage.filename.split('.HEIC')[0] +
+                    '.jpg',
                   type: newImage.mime,
                   uri: newImage.path,
                 };

--- a/src/myapp/hooks/images/useLaunchCamera.ts
+++ b/src/myapp/hooks/images/useLaunchCamera.ts
@@ -56,7 +56,11 @@ const useLaunchCamera = (setImage: (image: ImageSourcePropType) => void) => {
                 compressImageMaxWidth: 500,
               }).then((newImage) => {
                 const imageData = {
-                  fileName: newImage.filename.split('.HEIC')[0] + '.jpg',
+                  fileName:
+                    Date.now() +
+                    '-' +
+                    newImage.filename.split('.HEIC')[0] +
+                    '.jpg',
                   type: newImage.mime,
                   uri: newImage.path,
                 };


### PR DESCRIPTION
To prevent two files from being named exactly the same. For example, if two files were downloaded and named descarga.jpg. This issue is iOS only since the library used in android adds it automatically.